### PR TITLE
コメントしたユーザーを表示

### DIFF
--- a/src/screens/DetailScreen.vue
+++ b/src/screens/DetailScreen.vue
@@ -206,7 +206,8 @@ export default {
       const data = {
         text: this.newComment,
         shop_id: this.shopId,
-        code: this.code
+        code: this.code,
+        user_id: store.state.auth.user.id
       } 
       store.dispatch("comment/saveComment", data)
         .then(res => {

--- a/src/screens/DetailScreen.vue
+++ b/src/screens/DetailScreen.vue
@@ -96,7 +96,7 @@
               <nb-thumbnail small :source="require('../../assets/icon.png')"/>
             </nb-left>
             <nb-body>
-              <nb-text>miku</nb-Text>
+              <nb-text>{{ comment.user.nickname }}</nb-Text>
               <nb-text note>{{ comment.text }}</nb-Text>
             </nb-body>
             <nb-right>


### PR DESCRIPTION
# What
店舗情報ページのコメント箇所で、ユーザーネームが確認できるようにする。また、コメント保存時、ログインユーザーのユーザーIDも保存するようにリクエスト値を追加する。

# Why
ユーザビリティを高めるため。