### PR TITLE
お気に入り解除機能修正 #34

### DIFF
--- a/src/screens/DetailScreen.vue
+++ b/src/screens/DetailScreen.vue
@@ -264,7 +264,7 @@ export default {
         }
         store.dispatch("comment/saveComment", data)
           .then(res => {
-            this.shopId = store.state.comment.newCommentShopId
+            this.shopId = store.state.shop.shopId
             this.newComment = ""
             // $dirtyをfalseに設定（コメント入力欄アクティブリセット）
             this.$v.newComment.$reset()
@@ -293,6 +293,7 @@ export default {
         }
         store.dispatch("favorite/saveFavorite", data)
           .then(res => {
+            this.shopId = store.state.shop.shopId
             console.log("お気に入り登録しました")
           })
           .catch(() => {

--- a/src/store/modules/comment.js
+++ b/src/store/modules/comment.js
@@ -35,7 +35,7 @@ export default {
       // 店舗が未登録なら、先に店舗を登録する
       if (data.commentData.shop_id == 0) {
         await dispatch('shop/saveShop', data.shopData, { root: true })
-        data.commentData['shop_id'] = rootState.shop.ShopId
+        data.commentData['shop_id'] = rootState.shop.shopId
       }
       return axios.post('http://192.168.100.100:8000/comments', data.commentData)
       .then(res => {

--- a/src/store/modules/favorite.js
+++ b/src/store/modules/favorite.js
@@ -53,7 +53,7 @@ export default {
       // 店舗が未登録なら、先に店舗を登録する
       if (data.favoriteData.shop_id == 0) {
         await dispatch('shop/saveShop', data.shopData, { root: true })
-        data.favoriteData.shop_id = rootState.shop.ShopId
+        data.favoriteData.shop_id = rootState.shop.shopId
       }
       const strId = String(data.favoriteData.shop_id)
       delete data.favoriteData.shop_id

--- a/src/store/modules/shop.js
+++ b/src/store/modules/shop.js
@@ -57,7 +57,7 @@ export default {
       state.commentedShops = data
     },
     setShopId (state, shopId) {
-      state.ShopId = shopId
+      state.shopId = shopId
     },
   },
   actions: {


### PR DESCRIPTION
# What
お気に入り解除機能が自作APIとの連携が取れておらず、現状DBの削除処理がされていない。
ロジックを追加して、正常に削除処理がされるよう修正する。
変更後：
誤字が原因だったため、誤字修正のみでロジック追加はなし。

# Why
バグ修正。