### PR TITLE
API側context追加に伴うリクエストパラメータ変更 #44

### DIFF
--- a/src/screens/DetailScreen.vue
+++ b/src/screens/DetailScreen.vue
@@ -259,9 +259,8 @@ export default {
           },
           commentData: {
             text: this.newComment,
-            shop_id: this.shopId,
-            user_id: store.state.auth.user.id,
-          }
+          },
+          shop_id: this.shopId
         }
         store.dispatch("comment/saveComment", data)
           .then(res => {

--- a/src/screens/DetailScreen.vue
+++ b/src/screens/DetailScreen.vue
@@ -290,10 +290,7 @@ export default {
             longitude: this.marker.coordinate.longitude,
             url: this.url
           },
-          favoriteData: {
-            shop_id: this.shopId,
-            user_id: store.state.auth.user.id,
-          }
+          shop_id: this.shopId,
         }
         store.dispatch("favorite/saveFavorite", data)
           .then(res => {
@@ -308,13 +305,7 @@ export default {
           })
     },
     cancelFavoriteBtnPress() {
-      // APIに削除する店舗IDを投げる
-      const data = {
-        shop_id: this.shopId,
-        user_id: store.state.auth.user.id,
-      }
-      store.dispatch("favorite/delFavorite", data)
-      // stateから該当するデータを取り除く
+      store.dispatch("favorite/delFavorite", this.shopId)
     }
   },
   async created () {

--- a/src/screens/MylistScreen.vue
+++ b/src/screens/MylistScreen.vue
@@ -101,11 +101,7 @@ export default {
     },
   },
   created() {
-    if (this.isAuth) {
-      store.dispatch('shop/getCommentedAndFavoritedShops', store.state.auth.user.id)
-    }else{
-      store.dispatch('shop/getCommentedAndFavoritedShops', 0)
-    }
+    store.dispatch('shop/getCommentedAndFavoritedShops')
   }
 };
 </script>

--- a/src/store/modules/comment.js
+++ b/src/store/modules/comment.js
@@ -36,12 +36,11 @@ export default {
     // コメント保存
     async saveComment ({commit, dispatch, rootState}, data) {
       // 店舗が未登録なら、先に店舗を登録する
-      if (data.commentData.shop_id == 0) {
+      if (data.shop_id == 0) {
         await dispatch('shop/saveShop', data.shopData, { root: true })
-        data.commentData.shop_id = rootState.shop.shopId
+        data.shop_id = rootState.shop.shopId
       }
-      const strId = String(data.commentData.shop_id)
-      delete data.commentData.shop_id
+      const strId = String(data.shop_id)
       return axios.post('http://192.168.100.100:8000/shops/' + strId + '/comments', data.commentData)
       .then(res => {
         const newComment = res.data

--- a/src/store/modules/favorite.js
+++ b/src/store/modules/favorite.js
@@ -54,13 +54,12 @@ export default {
     // お気に入り保存
     async saveFavorite ({commit, dispatch, rootState, getters}, data) {
       // 店舗が未登録なら、先に店舗を登録する
-      if (data.favoriteData.shop_id == 0) {
+      if (data.shop_id == 0) {
         await dispatch('shop/saveShop', data.shopData, { root: true })
-        data.favoriteData.shop_id = rootState.shop.shopId
+        data.shop_id = rootState.shop.shopId
       }
-      const strId = String(data.favoriteData.shop_id)
-      delete data.favoriteData.shop_id
-      return axios.post('http://192.168.100.100:8000/shops/' + strId + '/favorites', data.favoriteData)
+      const strId = String(data.shop_id)
+      return axios.post('http://192.168.100.100:8000/shops/' + strId + '/favorites')
       .then(res => {
         commit('setNewFavorite', res.data)
       })
@@ -75,14 +74,11 @@ export default {
       return commit('resetFavoriteUser')
     },
     // お気に入り解除
-    delFavorite ({commit}, data) {
-      const strId = String(data.shop_id)
-      delete data.shop_id
-      return axios.delete('http://192.168.100.100:8000/shops/' + strId + '/favorites', {
-        data: data
-      })
+    delFavorite ({commit, rootState}, shopId) {
+      const strId = String(shopId)
+      return axios.delete('http://192.168.100.100:8000/shops/' + strId + '/favorites')
       .then(res => {
-        commit('resetFavorite', data.user_id)
+        commit('resetFavorite', rootState.auth.user.user_id)
       })
       .catch(err => {
         console.log(err)

--- a/src/store/modules/shop.js
+++ b/src/store/modules/shop.js
@@ -112,8 +112,8 @@ export default {
       })
     },
     // ユーザーがコメント・お気に入りした店舗情報を取得
-    getCommentedAndFavoritedShops ({commit}, uid) {
-      return axios.post('http://192.168.100.100:8000/shops/me', { user_id: uid })
+    getCommentedAndFavoritedShops ({commit}) {
+      return axios.get('http://192.168.100.100:8000/shops/me')
       .then(res => {
           commit('setCommentedAndFavoritedShops',res.data)
         })


### PR DESCRIPTION
# What
API側でcontextを追加しトークンからユーザーIDを取得できるようになったため、リクエストパラメータの受け渡しは削除する。

# Why
リファクタリング。